### PR TITLE
Fixed issue with sample/panorama_lower not loading

### DIFF
--- a/src/main/java/alexiil/mc/mod/load/CustomLoadingScreen.java
+++ b/src/main/java/alexiil/mc/mod/load/CustomLoadingScreen.java
@@ -65,7 +65,7 @@ public class CustomLoadingScreen {
                 + "\nOr you can set this to 'config/example' to use the default example config."
         );
 
-        String[] defaultRandoms = { "sample/default", "sample/white", "sample/scrolling", "sample_panorama_lower" };
+        String[] defaultRandoms = { "sample/default", "sample/white", "sample/scrolling", "sample/panorama_lower" };
         PROP_CONFIG_RANDOMS = CONFIG.get("general", "random_configs", defaultRandoms);
 
         PROP_WAIT = CONFIG.get("general", "smooth_init", true);


### PR DESCRIPTION
sample/panorama_lower was not loading by default and giving an error because code said sample_panorama_lower instead of sample/panorama_lower