### PR TITLE
Add I18n tips support

### DIFF
--- a/src/main/java/alexiil/mc/mod/load/Tips.java
+++ b/src/main/java/alexiil/mc/mod/load/Tips.java
@@ -8,12 +8,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import javax.annotation.Nullable;
 
 /** Basic tips manager. Provides access to a single list of tips. */
 public class Tips {
 
+    private static String language = "en_us";
     private static final List<String> tips = new ArrayList<>();
     private static boolean anyTips = false;
 
@@ -23,6 +25,19 @@ public class Tips {
     }
 
     public static void load() {
+        File options = new File("options.txt");
+        try (BufferedReader reader = new BufferedReader(new FileReader(options))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split(":");
+                if (parts[0].equals("lang")) {
+                    language = parts[1].toLowerCase(Locale.ROOT);
+                }
+            }
+        } catch (IOException ignored) { }
+
+        CLSLog.info("Target tips language: " + language);
+
         File f = new File("config/customloadingscreen_tips.txt");
         if (!f.exists()) {
             try {
@@ -56,21 +71,53 @@ public class Tips {
         }
     }
 
-    public static void parseTips(BufferedReader from, List<String> to) throws IOException {
-        String line;
-        while ((line = from.readLine()) != null) {
-            if (line.isEmpty() || line.startsWith("#")) {
+    public static List<String> parseTips(BufferedReader from) throws IOException {
+        List<String> lines = new ArrayList<>();
+
+        boolean firstTipFlag = false;
+        boolean isFirstTipLangIndicator = false;
+        String _line;
+        while ((_line = from.readLine()) != null) {
+            _line = _line.trim();
+            if (_line.isEmpty() || _line.startsWith("#")) {
                 // Comment
             } else {
-                to.add(line);
+                if (!firstTipFlag) {
+                    firstTipFlag = true;
+                    isFirstTipLangIndicator = _line.startsWith("[") && _line.endsWith("]");
+                }
+                lines.add(_line);
             }
         }
-    }
 
-    public static List<String> parseTips(BufferedReader from) throws IOException {
-        List<String> list = new ArrayList<>();
-        parseTips(from, list);
-        return list;
+        List<String> availableLangs = new ArrayList<>();
+        for (String line: lines) {
+            if (line.startsWith("[") && line.endsWith("]")) {
+                String lang = line.substring(1, line.length() - 1).trim().toLowerCase(Locale.ROOT);
+                availableLangs.add(lang);
+            }
+        }
+        if (!availableLangs.contains("en_us") && !isFirstTipLangIndicator) {
+            availableLangs.add("en_us");
+        }
+        String targetLang = language;
+        if (!availableLangs.contains(targetLang)) {
+            targetLang = availableLangs.contains("en_us") ? "en_us" : availableLangs.get(0);
+        }
+
+        String currLangIndicator = "en_us";
+        List<String> output = new ArrayList<>();
+        for (String line: lines) {
+            if (line.startsWith("[") && line.endsWith("]")) {
+                currLangIndicator = line.substring(1, line.length() - 1).trim().toLowerCase(Locale.ROOT);
+            } else {
+                if (targetLang.equals(currLangIndicator)) {
+                    output.add(line);
+                }
+            }
+        }
+
+        return output;
     }
 
     public static String getFirstTip() {

--- a/src/main/java/alexiil/mc/mod/load/Tips.java
+++ b/src/main/java/alexiil/mc/mod/load/Tips.java
@@ -34,7 +34,9 @@ public class Tips {
                     language = parts[1].toLowerCase(Locale.ROOT);
                 }
             }
-        } catch (IOException ignored) { }
+        } catch (IOException io) {
+            CLSLog.warn("Failed to load language from options.txt", io);
+        }
 
         CLSLog.info("Target tips language: " + language);
 

--- a/src/main/java/alexiil/mc/mod/load/Tips.java
+++ b/src/main/java/alexiil/mc/mod/load/Tips.java
@@ -5,10 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 import javax.annotation.Nullable;
 
@@ -89,34 +86,60 @@ public class Tips {
             } else {
                 if (!firstTipFlag) {
                     firstTipFlag = true;
-                    isFirstTipLangIndicator = _line.startsWith("[") && _line.endsWith("]");
+                    isFirstTipLangIndicator = _line.startsWith("[lang:") && _line.endsWith("]");
                 }
                 lines.add(_line);
             }
         }
 
-        List<String> availableLangs = new ArrayList<>();
+        List<List<String>> availableLangs = new ArrayList<>();
         for (String line: lines) {
-            if (line.startsWith("[") && line.endsWith("]")) {
-                String lang = line.substring(1, line.length() - 1).trim().toLowerCase(Locale.ROOT);
-                availableLangs.add(lang);
+            if (line.startsWith("[lang:") && line.endsWith("]")) {
+                String langArg = line.substring(6, line.length() - 1).trim().toLowerCase(Locale.ROOT);
+                String[] args = langArg.split(",");
+                for (int i = 0; i < args.length; i++) {
+                    args[i] = args[i].trim();
+                }
+                availableLangs.add(Arrays.asList(args));
             }
         }
-        if (!availableLangs.contains("en_us") && !isFirstTipLangIndicator) {
-            availableLangs.add("en_us");
-        }
+
+        // Target lang not found edge case
+        boolean foundTargetLang = false;
         String targetLang = language;
-        if (!availableLangs.contains(targetLang)) {
-            targetLang = availableLangs.contains("en_us") ? "en_us" : availableLangs.get(0);
+        for (List<String> langs: availableLangs) {
+            if (langs.contains(targetLang)) {
+                foundTargetLang = true;
+                break;
+            }
+        }
+        if (!foundTargetLang) {
+            // Cuz we treat the first section as en_us section
+            boolean foundEN_US = !isFirstTipLangIndicator;
+            if (!foundEN_US) {
+                for (List<String> langs: availableLangs) {
+                    if (langs.contains("en_us")) {
+                        foundEN_US = true;
+                        break;
+                    }
+                }
+            }
+            // Falls back to en_us if possible
+            // Otherwise use the first language
+            targetLang = foundEN_US ? "en_us" : availableLangs.get(0).get(0);
         }
 
-        String currLangIndicator = "en_us";
+        // Treat the first section as en_us section
+        List<String> currLangIndicator = Collections.singletonList("en_us");
+        int langIndicatorIndex = 0;
+
         List<String> output = new ArrayList<>();
         for (String line: lines) {
-            if (line.startsWith("[") && line.endsWith("]")) {
-                currLangIndicator = line.substring(1, line.length() - 1).trim().toLowerCase(Locale.ROOT);
+            if (line.startsWith("[lang:") && line.endsWith("]")) {
+                // Fetch from pre-processed list
+                currLangIndicator = availableLangs.get(langIndicatorIndex++);
             } else {
-                if (targetLang.equals(currLangIndicator)) {
+                if (currLangIndicator.contains(targetLang)) {
                     output.add(line);
                 }
             }

--- a/src/main/java/alexiil/mc/mod/load/Tips.java
+++ b/src/main/java/alexiil/mc/mod/load/Tips.java
@@ -26,16 +26,19 @@ public class Tips {
 
     public static void load() {
         File options = new File("options.txt");
-        try (BufferedReader reader = new BufferedReader(new FileReader(options))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                String[] parts = line.split(":");
-                if (parts.length > 1 && parts[0].equals("lang")) {
-                    language = parts[1].toLowerCase(Locale.ROOT);
+        if (options.exists()) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(options))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String[] parts = line.split(":");
+                    if (parts.length > 1 && parts[0].equals("lang")) {
+                        language = parts[1].toLowerCase(Locale.ROOT);
+                        break;
+                    }
                 }
+            } catch (IOException io) {
+                CLSLog.warn("Failed to load language from options.txt", io);
             }
-        } catch (IOException io) {
-            CLSLog.warn("Failed to load language from options.txt", io);
         }
 
         CLSLog.info("Target tips language: " + language);

--- a/src/main/java/alexiil/mc/mod/load/Tips.java
+++ b/src/main/java/alexiil/mc/mod/load/Tips.java
@@ -30,7 +30,7 @@ public class Tips {
             String line;
             while ((line = reader.readLine()) != null) {
                 String[] parts = line.split(":");
-                if (parts[0].equals("lang")) {
+                if (parts.length > 1 && parts[0].equals("lang")) {
                     language = parts[1].toLowerCase(Locale.ROOT);
                 }
             }


### PR DESCRIPTION
My I18n approach is fully compatible with the current `customloadingscreen_tips.txt` format, allowing users to migrate seamlessly. (technically they don't even need to modify `customloadingscreen_tips.txt` to migrate)

## Parsing Algorithm
To illustrate, I keep the concept of `Language Indicator` in mind while reading tips from the file. For example,
```
[en_us]
line1
line2

[zh_cn]
line3
line4
```
so `line1` & `line2` will be fetched if `lang` from `options.txt` equals `en_us`.
In the case of a variant `customloadingscreen_tips.txt`, like
```
line1
line2

[zh_cn]
line3
line4
```
`line1` & `line2` will still be fetched since I treat the first section as `en_us` by default. i.e. users don't even need to add that `[en_us]` indicator to their existing tips file to function correctly.

## Edge Case
If the target language from `options.txt` isn't in our available language set, like
```
[lang1]
...

[lang2]
...
```
but client requests a `lang3`. In that case, target language falls back to `en_us` if `en_us` existed in `customloadingscreen_tips.txt`; otherwise, it falls back to the first language indicator.

